### PR TITLE
Fuse-2.9: remove boost dependancy from Fuse.h

### DIFF
--- a/Fuse.h
+++ b/Fuse.h
@@ -33,8 +33,6 @@
 #include <fuse.h>
 #include <string.h>
 
-#include <boost/noncopyable.hpp>
-
 namespace Fusepp
 {
   typedef int(*t_readlink)(const char *, char *, size_t);
@@ -78,7 +76,7 @@ namespace Fusepp
   typedef int(*t_fgetattr) (const char *, struct stat *,
                             struct fuse_file_info *);
 
-  template <class T> class Fuse : private boost::noncopyable
+  template <class T> class Fuse :
   {
   public:
     Fuse()
@@ -86,6 +84,13 @@ namespace Fusepp
       memset (&T::operations_, 0, sizeof (struct fuse_operations));
       load_operations_();
     }
+
+    // no copy
+    Fuse(const Fuse&) = delete;
+    Fuse& operator=(const Fuse&) = delete;
+    Fuse& operator= (Fuse&&) = delete;
+
+    ~Fuse() = default;
 
     int run(int argc, char **argv)
     {

--- a/fusehad/HaD.cpp
+++ b/fusehad/HaD.cpp
@@ -1,0 +1,19 @@
+#include <stdio.h>
+
+#include "HaDFS.h"
+
+int main(int argc, char *argv[])
+{
+
+  HaDFS fs;
+  if (fs.userinit())
+    {
+      fprintf(stderr,"Can't fetch feed\n");
+      return 99;
+    };
+  int status;
+  status= fs.run(argc, argv);
+  
+
+  return status;
+}

--- a/fusehad/HaDFS.cpp
+++ b/fusehad/HaDFS.cpp
@@ -1,0 +1,201 @@
+// Hackaday RSS filesystem class implementation
+
+#include "HaDFS.h"
+
+#include <iostream>
+#include <stdio.h>  // using popen
+#include <string>
+#include <array>
+
+// include in one .cpp file
+#include "Fuse-impl.h"
+
+using namespace std;
+
+static const string root_path = "/";
+
+// Maximum number of topics
+#define MAXTOPIC ((unsigned long)128)
+static unsigned topics=0;  // number of topics we've seen
+
+// Record for RSS item
+struct a_topic
+{
+  string title;  // title
+  string url;    // URL
+  string content;  // content
+};
+
+// Where the topics live
+array<a_topic,MAXTOPIC> topic;
+
+
+// The curl line to read our feed
+static char cmd[]="curl https://hackaday.com/feed/ 2>/dev/null | egrep '(<title>)|(<link>)'";
+
+// Trim RSS lines to kill leading spaces and the last </...> part
+// We are assuming the format will not have multiple things on one line
+// Although that isn't a great assumption
+static string trimrss(const string &str, const string &white1 = " \t\r\n", const string &white2 = "<")
+{
+  size_t first, last;
+  first=str.find_first_not_of(white1);
+  if (first==string::npos) return "";
+  last=str.find_last_of(white2);
+  if (last==string::npos) last=str.length()-1; else last--;  // untested if there is no <...> at the end
+  return str.substr(first,last-first+1);
+}
+
+// Find a path and return a file descriptor (can't be zero so we add 1 to it)
+int HaDFS::pathfind(const char *path)
+{
+  string s=path;
+  if (s.find_first_of('/')!=string::npos)
+    {
+      // no subdirectories
+      return -1;
+    }
+  for (unsigned int i=0;i<topics;i++)
+    if (s==topic[i].title) return i+1;
+  return -1;
+}
+
+
+
+// Read the content or any URL for that matter
+static string readurl(string &url)
+{
+  FILE *fp;
+  char buf[1024];  // working buffer for reading strings
+    string result, curl="2>/dev/null curl '";
+    curl+=url;
+  curl+="'";
+  if (!(fp=popen(curl.c_str(),"r"))) return "";
+  while (fgets(buf,sizeof(buf),fp))
+    {
+      result+=buf;
+      result+="\n";
+    }
+  pclose(fp);
+  return result;
+}
+
+// User initialization--read the feed (note that init is reserved by the FUSE library)
+int HaDFS::userinit(void)
+{
+
+  FILE *fp;
+  char buf[1024];  // working buffer for reading strings
+  if (!(fp=popen(cmd,"r"))) return 1;  // open pipe
+  while (fgets(buf,sizeof(buf),fp))
+    {
+      string line=buf;
+      line=trimrss(line);  // trim off extra stuff
+      if (line.substr(0,7)=="<title>")    // identify line type and process
+	{
+	  topic[topics].title=line.substr(7);
+	  topic[topics].title+=".html";
+
+	}
+      else if (line.substr(0,6)=="<link>")
+	{
+	  topic[topics].url=line.substr(6);
+	  topics++;
+	  if (topics==MAXTOPIC) break;   // quietly truncate a long feed
+	}
+    }
+  pclose(fp);
+  return 0;
+}
+
+
+// Fuse wants to stat our files
+int HaDFS::getattr(const char *path, struct stat *stbuf)
+{
+        int res = 0,n;
+	memset(stbuf, 0, sizeof(struct stat));
+	if (path == root_path)
+	  {
+	    stbuf->st_mode = S_IFDIR | 0755;   // our root directory
+	    stbuf->st_nlink = 2;
+	  }
+	else if ((n=pathfind(path+1))>0)   // find path (skip leading /)
+	  {
+	    stbuf->st_mode = S_IFREG | 0444;  // read only
+	    stbuf->st_nlink = 1;   // no links
+	    if (topic[n-1].content.empty())  // if empty, go ahead and fill content cache
+	      {
+		topic[n-1].content=readurl(topic[n-1].url);  
+	      }
+	    stbuf->st_size = topic[n-1].content.length();  // now we know the length
+	  }
+	else
+	  {
+	  res = -ENOENT;  // not found
+	  }
+	return res;
+}
+
+// Fuse wants to read a directory
+int HaDFS::readdir(const char *path, void *buf, fuse_fill_dir_t filler,
+			 off_t, struct fuse_file_info *)
+{
+  if (path != root_path)  // only root is valid
+    return -ENOENT;
+  // we always have . and ..
+  filler(buf, ".", NULL, 0);
+  filler(buf, "..", NULL, 0);
+  // plus all of our "files"
+  for (unsigned int i=0;i<topics;i++)
+    filler(buf, topic[i].title.c_str(), NULL, 0);
+  return 0;
+}
+
+
+// Fuse wants to open a file
+int HaDFS::open(const char *path, struct fuse_file_info *fi)
+{
+       string fn=path+1;  // skip leading /
+       int n;
+       if (fn.find_first_of('/')!=string::npos) return -ENOENT;  // no sub dirs
+       if ((n=pathfind(fn.c_str()))==-1)    // find fd
+	 return -ENOENT;
+
+       if ((fi->flags & 3) != O_RDONLY)  // must be read only
+	 return -EACCES;
+// fi->fh is file handle
+       fi->fh=n;
+       if (topic[n-1].content.empty())  // if we have no content in cache, try to read now
+	 {
+	   topic[n-1].content=readurl(topic[n-1].url);
+	 }
+	return 0;
+}
+
+
+// Fuse wants to read something
+int HaDFS::read(const char *path, char *buf, size_t size, off_t offset,
+		              struct fuse_file_info *fi)
+{
+	size_t len;
+	len = topic[fi->fh-1].content.length();  // we get the length
+	if ((size_t)offset < len)  // if the offset isn't past the end...
+	  {
+	    if (offset + size > len)
+	      size = len - offset;
+	    memcpy(buf, topic[fi->fh-1].content.c_str() + offset, size);  // get the data over to the buffer
+	  } else
+	  size = 0;  // no data here
+	return size;
+}
+
+
+
+
+
+
+
+
+
+
+

--- a/fusehad/HaDFS.h
+++ b/fusehad/HaDFS.h
@@ -1,0 +1,36 @@
+// Hackaday filesystem class definition
+
+#ifndef __FUSEHAD_H_
+#define __FUSEHAD_H_
+
+#include "Fuse.h"
+
+#include "Fuse-impl.h"
+
+class HaDFS : public Fusepp::Fuse<HaDFS>
+{
+public:
+  HaDFS() {}
+
+  ~HaDFS() {}
+
+  static int getattr (const char *, struct stat *);
+
+  static int readdir(const char *path, void *buf,
+                     fuse_fill_dir_t filler,
+                     off_t offset, struct fuse_file_info *fi);
+  
+  static int open(const char *path, struct fuse_file_info *fi);
+
+  static int read(const char *path, char *buf, size_t size, off_t offset,
+                  struct fuse_file_info *fi);
+
+  static int userinit(void);
+
+  static int pathfind(const char *path);
+
+
+
+};
+
+#endif

--- a/fusehad/Makefile
+++ b/fusehad/Makefile
@@ -1,0 +1,28 @@
+PROG=HaD-2.9
+OBJDIR=.obj
+CC=g++
+
+CFLAGS = -Wall --std=c++14 $(shell pkg-config fuse --cflags) -I..
+LDFLAGS = $(shell pkg-config fuse --libs)
+
+$(shell mkdir -p $(OBJDIR)) 
+
+OBJS = $(OBJDIR)/HaD.o $(OBJDIR)/HaDFS.o
+
+$(PROG) : $(OBJS)
+	$(CC) $(OBJS) $(LDFLAGS) -o $(PROG)
+
+-include $(OBJS:.o=.d)
+
+$(OBJDIR)/%.o: %.cpp
+	$(CC) -c $(CFLAGS) $*.cpp -o $(OBJDIR)/$*.o
+	$(CC) -MM $(CFLAGS) $*.cpp > $(OBJDIR)/$*.d
+	@mv -f $(OBJDIR)/$*.d $(OBJDIR)/$*.d.tmp
+	@sed -e 's|.*:|$(OBJDIR)/$*.o:|' < $(OBJDIR)/$*.d.tmp > $(OBJDIR)/$*.d
+	@sed -e 's/.*://' -e 's/\\$$//' < $(OBJDIR)/$*.d.tmp | fmt -1 | \
+	  sed -e 's/^ *//' -e 's/$$/:/' >> $(OBJDIR)/$*.d
+	@rm -f $(OBJDIR)/$*.d.tmp
+
+clean:
+	rm -rf $(PROG) $(OBJDIR)
+

--- a/fusehad/README.md
+++ b/fusehad/README.md
@@ -1,0 +1,62 @@
+# Hackaday RSS feed, mountable as a normal filesystem
+
+(for LibFuse v2, at least v2.9 according to original repo)
+
+https://hackaday.com/2022/02/16/linux-fu-fusing-hackaday/
+
+![Hackaday RSS filesystem](https://hackaday.com/wp-content/uploads/2022/02/mount.png)
+
+---
+
+## Constraints
+
+To keep things simple, I decided not to worry about performance too much. Since the data is traveling over the network, I do attempt to cache it, and I don’t refresh data later. Of course, you can’t write to the filesystem at all. This is purely for reading Hackaday.
+
+These constraints make things easier. Of course, if you were writing your own filesystem, you might relax some of these, but it still helps to get something as simple as possible working first.
+
+
+## Making it work first
+
+Speaking of which, the first order of business is to be able to read the Hackaday RSS feed and pull out the parts we need. Again, not worrying about performance, I decided to do that with a pipe and calling out to `curl`. Yes, that’s cheating, but it works just fine, and that’s why we have tools in the first place.
+
+The `HaDFS.cpp` file has a few functions related to FUSE and some helper functions, too. However, I wanted to focus on getting the RSS feed working so I put the related code into a function I made up called `userinit`. I found out the hard way that naming it `init` would conflict with the library.
+
+The normal FUSE system processes your command line arguments — a good thing, as you’ll see soon.
+
+Reading the feed isn’t that hard since I’m conscripting `curl`. Each topic is in a structure and there is an array of these structures. If you try to load too many stories, the code just quietly discards the excess (see `MAXTOPIC`). The `topics` global variable tells how many stories we’ve actually loaded.
+
+The `popen` function runs a command line and gives us the `stdout` stream as a bunch of lines. Processing the lines is just brute force looking for <title> and <link> to identify the data we need. I filtered curl through `grep` to make sure I didn’t get a lot of extra lines, by the way, and I assumed lowercase, but a `-i` option could easily fix that. The redirect is to prevent `curl` from polluting `stderr`, although normally FUSE will disconnect the output streams so it doesn’t really matter. Note that I add an HTML extension to each fake file name so opening one is more likely to get to the browser.
+
+
+## The Four Functions
+
+There are four functions we need to create in a subclass to get a minimal read-only filesystem going: `getattr`, `readdir`, `open`, and `read`. These functions pretty much do what you expect.  The `getattr` call will return 755 for our root (and only) directory and 444 for any other file that exists. The `readdir` outputs entries for . and .. along with our “files.” `open` and `read` do just what you think they do.
+
+There are some other functions, but those are ones I added to help myself:
+
+ * `userinit` – Called to kick off the file system data
+ * `trimrss` – Trim an RSS line to make it easier to parse
+ * `pathfind` – Turn a file name into a descriptor (an index into the array of topics)
+ * `readurl` – Return a string with the contents of a URL (uses curl)
+
+There’s not much to it. You’ll see in the code that there are a few things to look out for like catching someone trying to write to a file since that isn’t allowed.
+
+
+## Debugging and command line options
+
+Of course, it doesn’t matter how simple it is, it isn’t going to work the first time is it? But, of course, things won’t work like you expect for any of a number of reasons. There are a few things to remember as you go about running and debugging.
+
+When you build your executable, you simply run it and provide a command line argument to specify the mount point which, of course, should exist. I have a habit of using `/tmp/mnt` while debugging, but it can be anywhere you have permissions.
+
+Under normal operation, FUSE detaches your program so you can’t just kill it. You’ll need to use unmount command (`fusermount -u`) with the mount point as an argument. Even if your program dies with a segment fault, you’ll need to use the unmount command or you will probably get the dreaded “disconnected endpoint” error message.
+
+Being detached leads to a problem. If you put `printf` statements in your code, they will never show up after detachment. For this reason, FUSE understands the `-f` flag which tells the system to keep your filesystem running in the foreground. Then you can see messages and a clean exit, like a Control+C, will cleanly unmount the filesystem. You can also use `-d` which enables some built-in debugging and implies `-f`. The `-s` flag turns off threading which can make debugging easier, or harder if you are dealing with a thread-related problem.
+
+You can use `gdb`, and there are some [good articles](https://blog.jeffli.me/blog/2014/08/30/use-gdb-to-understand-fuse-file-system/) about that. But for such a simple piece of code, it isn’t really necessary.
+
+
+## What's next?
+
+Read the rest of [the article on hackaday](https://hackaday.com/2022/02/16/linux-fu-fusing-hackaday/) to find out more related information.
+
+


### PR DESCRIPTION
Tested and verified, reused code from Fuse3 refactor to remove the
dependancy on '#include <boost/noncopyable.hpp>' in 'Fuse.h'.

(I already submitted this to the main repo - incase that takes a while to be processed, this will allow the next PR on this branch - being the `fusehad/` folder)