### PR TITLE
Fuse-2.9: fix Fuse.h compilation error

### DIFF
--- a/Fuse.h
+++ b/Fuse.h
@@ -76,7 +76,7 @@ namespace Fusepp
   typedef int(*t_fgetattr) (const char *, struct stat *,
                             struct fuse_file_info *);
 
-  template <class T> class Fuse :
+  template <class T> class Fuse
   {
   public:
     Fuse()


### PR DESCRIPTION
same fix as provided for https://github.com/jachappell/Fusepp/issues/9